### PR TITLE
 Fixed of the language error on searchbox

### DIFF
--- a/searchform.php
+++ b/searchform.php
@@ -17,6 +17,6 @@ if ( !defined('ABSPATH')) exit;
 
 <form method="get" class="searchform" action="<?php echo home_url(); ?>/">
 	<div id="magnify"><img src="<?php echo get_template_directory_uri() ;?>/images/magnify.png" alt="magnify" /></div>
-	<div><input type="text" name="s" class="s" id="searchsubmit" placeholder="<?php printf( __( 'Search', 'core' ); ?>" /></div>
+	<div><input type="text" name="s" class="s" id="searchsubmit" placeholder="<?php printf( __( 'Search', 'core' )); ?>" /></div>
 	<div><input type="submit" class="searchsubmit" value="" /></div>
 </form>


### PR DESCRIPTION
Replaced the javascript by placeholder atribute.
The error occurs when using the theme in a language other than English and compared 'Search' with 'Buscar' for example and no match.
